### PR TITLE
Add whatwg-fetch to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "15.3.2",
-    "react-native": "0.37.0"
+    "react-native": "0.37.0",
+    "whatwg-fetch": "^1.1.1"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
When I ran `npm install` for the first time on this project, I noticed this warning:
```
npm WARN jest-react-native@17.0.0 requires a peer of whatwg-fetch@^1.0.0 but none was installed.
```
I manually installed the dependency and that fixed the warning.